### PR TITLE
WIP: bug in event/cors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /log/*
 !/log/.keep
 /tmp
+
+/vendor/bundle

--- a/app/assets/javascripts/cors.coffee
+++ b/app/assets/javascripts/cors.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/cors.scss
+++ b/app/assets/stylesheets/cors.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Cors controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -1,8 +1,12 @@
 class API::EventsController < ApplicationController
+  allow_cors :create
   skip_before_action :verify_authenticity_token
 
   def create
-    
+    # p "********"
+    # p request.inspect
+    # p "********"
+
     registered_application = RegisteredApplication.find_by(url: request.env['HTTP_ORIGIN'])
 
     if registered_application

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,26 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  # protect_from_forgery with: :exception
+
+  def self.cors_allowed_actions 
+    @cors_allowed_actions ||= []
+  end
+
+  def self.cors_allowed_actions=(arr)
+    @cors_allowed_actions = arr
+  end
+
+  def self.allow_cors(*methods)
+    self.cors_allowed_actions += methods
+    before_filter :cors_allowed_actions, :only => methods
+    protect_from_forgery with: :null_session, :only => methods
+  end
+
+  # Overload handle_unverified_request to ensure that
+  # exception is raised each time a request does not
+  # pass validation.
+  def handle_unverified_request
+    raise(ActionController::InvalidAuthenticityToken)
+  end
 end

--- a/app/controllers/cors_controller.rb
+++ b/app/controllers/cors_controller.rb
@@ -1,0 +1,54 @@
+class CorsController < ApplicationController
+  def preflight
+    begin
+      http_request_verb = request.headers['Access-Control-Request-Method']
+
+      raise unless ["POST", "OPTIONS"].include? http_request_verb
+
+      p request.original_fullpath
+      # p request.inspect
+      # This line will raise an exception if the path does not resolve to any controller/action.
+      details = Rails.application.routes.recognize_path(request.original_fullpath, :method => http_request_verb.downcase.to_sym)
+      # details looks something like this { :controller => "posts", :action => "index" }
+
+
+      # # p "Details: " + details
+      # p "Deatils controller: " + details[:conrtoller]
+
+      # Convert to the controller class name (posts => PostsController)
+      # controller_class_name = details[:controller].camelize + "Controller"
+      controller_class_name = "#{details[:controller].camelize}Controller"
+      # Since we recorded the action names as symbol, we should convert it to symbol here
+      action_name = details[:action].to_sym
+
+      p controller_class_name.to_s
+
+      # If this statement returns true, then CORS is allowed
+      if eval(controller_class_name).cors_allowed_actions.include?(action_name)
+        p "*"*8
+        p "Post is allowed"
+        headers['Access-Control-Allow-Origin']  = request.headers['Origin']
+
+        p request.headers['Origin'] 
+        p headers['Access-Control-Allow-Origin']
+
+        p "*"*8
+
+        headers['Access-Control-Allow-Methods'] = http_request_verb
+        # Change this to something smaller while you are debugging
+        headers['Access-Control-Max-Age']       = "1728000"
+        # Change this to the list of accepted headers, or remove it if you do not accept any.
+        headers['Access-Control-Allow-Headers'] = request.headers['Access-Control-Request-Headers']
+      end
+    rescue Exception => e
+      p "*"*8
+      p "exception thrown"
+      p request.headers['Access-Control-Request-Method']
+      p e.message
+      p e.backtrace.inspect
+      p "*"*8
+    end
+    # Render empty stuff since preflight requests care only about the headers
+    render :text => "", :content_type => 'text/plain'
+  end
+end

--- a/app/helpers/cors_helper.rb
+++ b/app/helpers/cors_helper.rb
@@ -1,0 +1,2 @@
+module CorsHelper
+end

--- a/app/views/cors/preflight.html.erb
+++ b/app/views/cors/preflight.html.erb
@@ -1,0 +1,2 @@
+<h1>Cors#preflight</h1>
+<p>Find me in app/views/cors/preflight.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 
   devise_for :users
   get 'welcome/about'
+  get 'welcome/index'
 
   # show that this users_controller does not intercept devise actions.
   resources :users, only: :show
@@ -15,6 +16,7 @@ Rails.application.routes.draw do
     resources :events, only: [:create]
   end
 
+  match '*path' => 'cors#preflight', :via => :options
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/public/blocmetrics.js
+++ b/public/blocmetrics.js
@@ -1,0 +1,25 @@
+(function(window) {
+  var blocmetrics = window.blocmetrics || window.Blocmetrics || {};
+
+  function trackEvent(event) {
+    var _bm_request = new XMLHttpRequest();
+   
+    _bm_request.open("POST", "http://localhost:3000/api/events", true);
+     _bm_request.setRequestHeader("Content-Type", "application/json");
+    _bm_request.onreadystatechange = function() {
+      // left empty
+    };
+    _bm_request.send(JSON.stringify(event));
+  }
+
+   blocmetrics.report = function () {
+    var _bm_event = {
+      event_name: "sale",
+    }
+    trackEvent(_bm_event)
+  }
+
+  window.blocmetrics = blocmetrics
+}(window));
+
+


### PR DESCRIPTION
Hi, got a bug here.  I made changes according to 
http://www.yihangho.com/rails-cross-origin-resource-sharing/

I manage to get past preflight and to post. Post then throw an error on undefined method.
The method is a Class method and I can invoke it via pry and it did work in options case. 
The funny thing is that I do not understand the stack trace at all.  There application classes there at all.

and cors_allowed_actions are called only CorsController.  In EventsController, only allow_cors are used.  Please help.  Stuck.  run out of ideas.

 undefined method `cors_allowed_actions' for #API::EventsController:0x007fb9da1b3618
## activesupport (4.2.0) lib/active_support/callbacks.rb, line 427

``` ruby
  422         # All of these objects are converted into a lambda and handled
  423         # the same after this point.
  424         def make_lambda(filter)
  425           case filter
  426           when Symbol
> 427             lambda { |target, _, &blk| target.send filter, &blk }
  428           when String
  429             l = eval "lambda { |value| #{filter} }"
  430             lambda { |target, value| target.instance_exec(value, &l) }
  431           when Conditionals::Value then filter
  432           when ::Proc
```
## Full backtrace
- activesupport (4.2.0) lib/active_support/callbacks.rb:427:in `block in make_lambda'
- activesupport (4.2.0) lib/active_support/callbacks.rb:145:in `block in halting_and_conditional'
- activesupport (4.2.0) lib/active_support/callbacks.rb:234:in `block in halting'
- activesupport (4.2.0) lib/active_support/callbacks.rb:169:in `block in halting'
- activesupport (4.2.0) lib/active_support/callbacks.rb:169:in `block in halting'
- activesupport (4.2.0) lib/active_support/callbacks.rb:92:in `_run_callbacks'
- activesupport (4.2.0) lib/active_support/callbacks.rb:734:in `_run_process_action_callbacks'
- activesupport (4.2.0) lib/active_support/callbacks.rb:81:in `run_callbacks'
- actionpack (4.2.0) lib/abstract_controller/callbacks.rb:19:in `process_action'
- actionpack (4.2.0) lib/action_controller/metal/rescue.rb:29:in `process_action'
- actionpack (4.2.0) lib/action_controller/metal/instrumentation.rb:31:in `block in process_action'
- activesupport (4.2.0) lib/active_support/notifications.rb:164:in `block in instrument'
- activesupport (4.2.0) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
- activesupport (4.2.0) lib/active_support/notifications.rb:164:in `instrument'
- actionpack (4.2.0) lib/action_controller/metal/instrumentation.rb:30:in `process_action'
- actionpack (4.2.0) lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
- activerecord (4.2.0) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
- actionpack (4.2.0) lib/abstract_controller/base.rb:137:in `process'
- actionview (4.2.0) lib/action_view/rendering.rb:30:in `process'
- actionpack (4.2.0) lib/action_controller/metal.rb:195:in `dispatch'
- actionpack (4.2.0) lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
- actionpack (4.2.0) lib/action_controller/metal.rb:236:in `block in action'
- actionpack (4.2.0) lib/action_dispatch/routing/route_set.rb:73:in `dispatch'
- actionpack (4.2.0) lib/action_dispatch/routing/route_set.rb:42:in `serve'
- actionpack (4.2.0) lib/action_dispatch/journey/router.rb:43:in `block in serve'
- actionpack (4.2.0) lib/action_dispatch/journey/router.rb:30:in `serve'
- actionpack (4.2.0) lib/action_dispatch/routing/route_set.rb:802:in `call'
- warden (1.2.3) lib/warden/manager.rb:35:in `block in call'
- warden (1.2.3) lib/warden/manager.rb:34:in `call'
- rack (1.6.0) lib/rack/etag.rb:24:in `call'
- rack (1.6.0) lib/rack/conditionalget.rb:38:in `call'
- rack (1.6.0) lib/rack/head.rb:13:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/flash.rb:260:in `call'
- rack (1.6.0) lib/rack/session/abstract/id.rb:225:in `context'
- rack (1.6.0) lib/rack/session/abstract/id.rb:220:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/cookies.rb:560:in `call'
- activerecord (4.2.0) lib/active_record/query_cache.rb:36:in `call'
- activerecord (4.2.0) lib/active_record/connection_adapters/abstract/connection_pool.rb:647:in `call'
- activerecord (4.2.0) lib/active_record/migration.rb:378:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
- activesupport (4.2.0) lib/active_support/callbacks.rb:88:in `_run_callbacks'
- activesupport (4.2.0) lib/active_support/callbacks.rb:734:in `_run_call_callbacks'
- activesupport (4.2.0) lib/active_support/callbacks.rb:81:in `run_callbacks'
- actionpack (4.2.0) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/reloader.rb:73:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
- better_errors (2.1.1) lib/better_errors/middleware.rb:84:in `protected_app_call'
- better_errors (2.1.1) lib/better_errors/middleware.rb:79:in `better_errors_call'
- better_errors (2.1.1) lib/better_errors/middleware.rb:57:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
- web-console (2.1.2) lib/web_console/middleware.rb:37:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
- railties (4.2.0) lib/rails/rack/logger.rb:38:in `call_app'
- railties (4.2.0) lib/rails/rack/logger.rb:20:in `block in call'
- activesupport (4.2.0) lib/active_support/tagged_logging.rb:68:in `block in tagged'
- activesupport (4.2.0) lib/active_support/tagged_logging.rb:26:in `tagged'
- activesupport (4.2.0) lib/active_support/tagged_logging.rb:68:in `tagged'
- railties (4.2.0) lib/rails/rack/logger.rb:20:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/request_id.rb:21:in `call'
- rack (1.6.0) lib/rack/methodoverride.rb:22:in `call'
- rack (1.6.0) lib/rack/runtime.rb:18:in `call'
- activesupport (4.2.0) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
- rack (1.6.0) lib/rack/lock.rb:17:in `call'
- actionpack (4.2.0) lib/action_dispatch/middleware/static.rb:113:in `call'
- rack (1.6.0) lib/rack/sendfile.rb:113:in `call'
- railties (4.2.0) lib/rails/engine.rb:518:in `call'
- railties (4.2.0) lib/rails/application.rb:164:in `call'
- rack (1.6.0) lib/rack/content_length.rb:15:in `call'
- puma (2.11.1) lib/puma/server.rb:507:in `handle_request'
- puma (2.11.1) lib/puma/server.rb:375:in `process_client'
- puma (2.11.1) lib/puma/server.rb:262:in `block in run'
- puma (2.11.1) lib/puma/thread_pool.rb:104:in `block in spawn_thread'
